### PR TITLE
For 2.0, rename to block-module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "asgardcms/block",
+  "name": "asgardcms/block-module",
   "description": "A module to create small blocks of content to display anywhere on the site.",
   "type": "asgard-module",
   "license": "MIT",


### PR DESCRIPTION
To keep convention with all other modules ending with `-module`.
