### PR TITLE
add ability to disable WYSIWYG on blocks

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -46,4 +46,14 @@ return [
     | No custom sidebar: null
     */
     'custom-sidebar' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Use WYSIWYG editor
+    |--------------------------------------------------------------------------
+    | You can disable WYSIWYG editor if you prefer to edit HTML directly
+    | It is useful for example if you want to make a block with piece of Javascript
+    | (Google Maps), that would get stripped out by WYSIWYG filter
+     */
+    'use-wysiwyg' => true,
 ];

--- a/Resources/views/admin/blocks/partials/create-fields.blade.php
+++ b/Resources/views/admin/blocks/partials/create-fields.blade.php
@@ -1,5 +1,9 @@
 <div class="box-body">
-    @editor('body', trans('block::blocks.body'), old("{$lang}.body"), $lang)
+    @if (config('asgard.block.config.use-wysiwyg'))
+        @editor('body', trans('block::blocks.body'), old("{$lang}.body"), $lang)
+    @else
+        {!! Form::i18nTextarea('body', trans('block::blocks.body'), $errors, $lang, null, ['class' => 'form-control']) !!}
+    @endif
 
     {!! Form::i18nCheckbox('online', trans('block::blocks.online'), $errors, $lang) !!}
 

--- a/Resources/views/admin/blocks/partials/edit-fields.blade.php
+++ b/Resources/views/admin/blocks/partials/edit-fields.blade.php
@@ -1,6 +1,11 @@
 <div class="box-body">
     <?php $old = $block->hasTranslation($lang) ? $block->translate($lang)->body : '' ?>
-    @editor('body', trans('page::pages.form.body'), old("$lang.body", $old), $lang)
+    @if (config('asgard.block.config.use-wysiwyg'))
+        @editor('body', trans('block::blocks.body'), old("$lang.body", $old), $lang)
+    @else
+        {!! Form::i18nTextarea('body', trans('block::blocks.body'), $errors, $lang, $block, ['class' => 'form-control']) !!}
+    @endif
+
 
     {!! Form::i18nCheckbox('online', trans('block::blocks.online'), $errors, $lang, $block) !!}
 


### PR DESCRIPTION
This is useful when I would like to create block with some custom HTML / JavaScript, such as google maps JS snippet, small Vue.js app, etc - stuff that can get stripped out by WYSIWYG filter.

It should be used carefully, but is very helpful.