### PR TITLE
add Shortcode to blocks and allow to render blocks in any user-edited content

### DIFF
--- a/Entities/Block.php
+++ b/Entities/Block.php
@@ -6,6 +6,13 @@ use Dimsav\Translatable\Translatable;
 use Illuminate\Database\Eloquent\Model;
 use Laracasts\Presenter\PresentableTrait;
 
+/**
+ * Class Block
+ * @property string $name
+ * @property bool $online
+ * @property string $body
+ * @property string $shortcode
+ */
 class Block extends Model
 {
     use Translatable, PresentableTrait;
@@ -32,5 +39,10 @@ class Block extends Model
 
         #i: No relation found, return the call to parent (Eloquent) to handle it.
         return parent::__call($method, $parameters);
+    }
+
+    public function getShortcodeAttribute()
+    {
+        return sprintf('[[BLOCK(%s)]]', $this->name);
     }
 }

--- a/Http/Middleware/RenderBlock.php
+++ b/Http/Middleware/RenderBlock.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Modules\Block\Http\Middleware;
+
+use Illuminate\Http\Response;
+use Modules\Block\Repositories\BlockRepository;
+
+class RenderBlock
+{
+    /** @var BlockRepository */
+    private $blockRepository;
+
+    public function __construct(BlockRepository $blockRepository)
+    {
+        $this->blockRepository = $blockRepository;
+    }
+
+    public function handle($request, \Closure $next)
+    {
+        /** @var Response $response */
+        $response = $next($request);
+
+        // do not render galleries on backend
+        if (app('asgard.onBackend') === true) {
+            return $response;
+        }
+
+        // if this is not a standard Response, return right away
+        if(!$response instanceof Response) {
+            return $response;
+        }
+
+        $response->setContent($this->replaceShortcodes($response->getContent()));
+
+        return $response;
+    }
+
+    /**
+     * replaces all block shortcodes from the response HTML with the actual block body
+     * @param string $html
+     * @return string
+     */
+    private function replaceShortcodes($html)
+    {
+        preg_match_all('/\[\[BLOCK\((.*)\)\]\]/U', $html, $matches);
+        $replaceBlocks = [];
+        foreach ($matches[1] as $blockIndex => $blockName) {
+            // prevent loading same block twice
+            if (isset($replaceBlocks[$matches[0][$blockIndex]])) {
+                continue;
+            }
+
+            $replaceBlocks[$matches[0][$blockIndex]] = $this->blockRepository->get($blockName);
+        }
+
+        return str_replace(array_keys($replaceBlocks), $replaceBlocks, $html);
+
+    }
+}

--- a/Http/Middleware/RenderBlock.php
+++ b/Http/Middleware/RenderBlock.php
@@ -20,7 +20,7 @@ class RenderBlock
         /** @var Response $response */
         $response = $next($request);
 
-        // do not render galleries on backend
+        // do not replace shortcodes and render blocks on backend
         if (app('asgard.onBackend') === true) {
             return $response;
         }

--- a/Repositories/BlockRepository.php
+++ b/Repositories/BlockRepository.php
@@ -14,9 +14,9 @@ interface BlockRepository extends BaseRepository
     public function allOnlineInLang($lang);
 
     /**
-     * Get a block by its name if it's online
+     * Get a block body by its name if it's online
      * @param string $name
-     * @return object
+     * @return string
      */
     public function get($name);
 }

--- a/Repositories/Cache/CacheBlockDecorator.php
+++ b/Repositories/Cache/CacheBlockDecorator.php
@@ -33,9 +33,9 @@ class CacheBlockDecorator extends BaseCacheDecorator implements BlockRepository
     }
 
     /**
-     * Get a block by its name if it's online
+     * Get a block body by its name if it's online
      * @param string $name
-     * @return object
+     * @return string
      */
     public function get($name)
     {

--- a/Repositories/Eloquent/EloquentBlockRepository.php
+++ b/Repositories/Eloquent/EloquentBlockRepository.php
@@ -64,9 +64,9 @@ class EloquentBlockRepository extends EloquentBaseRepository implements BlockRep
     }
 
     /**
-     * Get a block by its name if it's online
+     * Get a block body by its name if it's online
      * @param string $name
-     * @return object
+     * @return string
      */
     public function get($name)
     {

--- a/Resources/lang/en/blocks.php
+++ b/Resources/lang/en/blocks.php
@@ -24,6 +24,7 @@ return [
     ],
     'online' => 'Online',
     'name' => 'Name',
+    'shortcode' => 'Shortcode',
     'body' => 'Body',
     'list resource' => 'List blocks',
     'create resource' => 'Create blocks',

--- a/Resources/views/admin/blocks/index.blade.php
+++ b/Resources/views/admin/blocks/index.blade.php
@@ -31,6 +31,7 @@
                             <th>Id</th>
                             <th>{{ trans('block::blocks.online') }}</th>
                             <th>{{ trans('block::blocks.name') }}</th>
+                            <th>{{ trans('block::blocks.shortcode') }}</th>
                             <th>{{ trans('core::core.table.created at') }}</th>
                             <th data-sortable="false">{{ trans('core::core.table.actions') }}</th>
                         </tr>
@@ -55,6 +56,9 @@
                                 </a>
                             </td>
                             <td>
+                                <pre>{{ $block->shortcode }}</pre>
+                            </td>
+                            <td>
                                 <a href="{{ route('admin.block.block.edit', [$block->id]) }}">
                                     {{ $block->created_at }}
                                 </a>
@@ -74,6 +78,7 @@
                             <th>Id</th>
                             <th>{{ trans('block::blocks.online') }}</th>
                             <th>{{ trans('block::blocks.name') }}</th>
+                            <th>{{ trans('block::blocks.shortcode') }}</th>
                             <th>{{ trans('core::core.table.created at') }}</th>
                             <th>{{ trans('core::core.table.actions') }}</th>
                         </tr>

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,51 @@ After this, you'll be able to get the content of a block with the following code
 {!! Block::get('block-name') !!}
 ```
 
+Each block also receives a shortcode that can be used instead of the code mentioned above. Shortcode looks like this `[[BLOCK(block-name)]]`.  
+This is very useful if you for example want to allow users to reuse and enter blocks into content of the WYSIWYG editor (page or blog article body)
+
+If you want to use shortcodes in your app, you need to register `RenderBlock` middleware responsible for parsing the response and replacing the shortcodes
+with the actual block content. It can be done globally by editing `app/Http/Kernel.php` file and adding `\Modules\Block\Http\Middleware\RenderBlock::class`
+into the `$middlewareGroups` `web` group (this way, block shortcodes will be automatically replaced in all `web` routes on frontend):
+```php
+ 
+<?php
+    // app/Http/Kernel.php
+    ...
+    protected $middlewareGroups = [
+        'web' => [
+            ...
+            \Modules\Block\Http\Middleware\RenderBlock::class,
+        ]
+    ...
+}
+```
+
+There are some drawbacks to this approach, specifically that each response will be parsed and searched for the shortcodes before returning
+back to the user, which may slightly slow down your application. If you know that you do not need to use shortcodes in the whole app,
+middleware can be applied selectively only to some routes or route groups in your application:
+
+```php
+<?php
+    // Modules/YourModule/Http/frontendRoutes.php
+    ...
+    // middleware will be applied to this specific route
+    $router->get('your-url', 'YourController@method')
+        ->middleware(\Modules\Block\Http\Middleware\RenderBlock::class);
+    ...
+    // middleware will be applied to whole group
+    $router->group(['middleware' => \Modules\Block\Http\Middleware\RenderBlock::class], function(Router $router) {
+        $router->get('your-url', 'YourController@method');
+        ...
+    });
+    ...
+?>
+
+```
+
+Keep in mind that by allowing users to put blocks/shortcodes anywhere, you are creating a potential security issue, so
+use this functionality carefully.  
+
 
 ### Hooks
 


### PR DESCRIPTION
Useful when users want to use blocks of code in WYSIWYG, without having to edit the underlying blade templates